### PR TITLE
added instructions to install dart-scss on nix based distribution

### DIFF
--- a/content/en/functions/resources/ToCSS.md
+++ b/content/en/functions/resources/ToCSS.md
@@ -117,6 +117,7 @@ Linux|Snap|[snapcraft.io]|`sudo snap install dart-sass`
 macOS|Homebrew|[brew.sh]|`brew install sass/sass/sass`
 Windows|Chocolatey|[chocolatey.org]|`choco install sass`
 Windows|Scoop|[scoop.sh]|`scoop install sass`
+Nixos|Nix|[nixos.org]|`nix-env -iA nixos.dart-sass`
 
 You may also install [prebuilt binaries] for Linux, macOS, and Windows.
 


### PR DESCRIPTION
The link to the package https://search.nixos.org/packages?channel=24.05&show=dart-sass&from=0&size=50&sort=relevance&type=packages&query=sass